### PR TITLE
Fix bug with annotations not showing when doing a task

### DIFF
--- a/task/templates/task/do_task_one_column.html
+++ b/task/templates/task/do_task_one_column.html
@@ -42,9 +42,9 @@
 
         {% block card_content_bottom %}
         {% if slide %}
-            {% include 'slide/view_wsi_do_task.html' with two_column=0 slide=slide annotated_slide=task.task.annotated_slide %}
+            {% include 'slide/view_wsi_do_task.html' with two_column=0 slide=slide annotated_slide=task.annotated_slide %}
         {% else %}
-            {% include 'slide/view_wsi_do_task.html' with slide=task.annotated_slide.slide annotated_slide=task.task.annotated_slide %}
+            {% include 'slide/view_wsi_do_task.html' with slide=slide annotated_slide=task.annotated_slide %}
         {% endif %}
         {% endblock card_content_bottom %}
     </div>

--- a/task/templates/task/do_task_two_column.html
+++ b/task/templates/task/do_task_two_column.html
@@ -46,9 +46,9 @@
             <div class="col-8" style="height: 100%;">
                 <div id="contentRight" style="width: 100%; height: 100%;">
                     {% if slide %}
-                        {% include 'slide/view_wsi_do_task.html' with two_column=1 slide=slide annotated_slide=task.task.annotated_slide %}
+                        {% include 'slide/view_wsi_do_task.html' with two_column=1 slide=slide annotated_slide=task.annotated_slide %}
                     {% else %}
-                        {% include 'slide/view_wsi_do_task.html' with slide=task.task.annotated_slide.slide annotated_slide=task.task.annotated_slide %}
+                        {% include 'slide/view_wsi_do_task.html' with slide=slide annotated_slide=task.annotated_slide %}
                     {% endif %}
                     {% block content_right %}
                     {% endblock content_right %}


### PR DESCRIPTION
After changing the `task` and question type names, forgot to update the lines where `slide` and `annotated_slide` are passed to the template that displays the WSIs. This resulted in the annotations not being shown.