### PR TITLE
Fixed thumbnail issues

### DIFF
--- a/slide/management/commands/insert_slide_data_into_database.py
+++ b/slide/management/commands/insert_slide_data_into_database.py
@@ -176,29 +176,9 @@ class Command(BaseCommand):
                         pathology=is_pathology,
                     )
                     slide.save()
-
-                    if path_to_slide.endswith('.vsi'):
-                        # Copy thumbnail.jpg file from data source to project files
-                        shutil.copyfile(
-                            src=os.path.join(os.path.split(path_to_slide)[0], 'thumbnail.jpg'),
-                            dst=os.path.join(thumbnails_dir, f'{slide.id}.jpg')
-                        )
+                    create_thumbnail(slide.id)
 
                     new_paths.append(path_to_slide)  # to ensure duplicates aren't added
-
-            else:  # Path already exists, retrieve existing entry
-                #try:
-                slide = Slide.objects.get(path=path_to_slide)
-                # Copy thumbnail.jpg file from data source to project files
-                if str(slide.id) + '.jpg' not in os.listdir(thumbnails_dir) \
-                        and path_to_slide.endswith('.vsi'):
-                    shutil.copyfile(
-                        src=os.path.join(os.path.split(path_to_slide)[0], 'thumbnail.jpg'),
-                        dst=os.path.join(thumbnails_dir, f'{slide.id}.jpg')
-                    )
-                #except Exception as exc:
-                #    # TODO: Catch exception if > 1 entry with same path exists
-                #    pass
 
             # ==== Add tags to slide (and to DB where missing) ====
             organ = slide_data['organ']

--- a/slide/management/commands/recreate_thumbnails.py
+++ b/slide/management/commands/recreate_thumbnails.py
@@ -1,0 +1,23 @@
+from django.core.management import BaseCommand
+from slide.models import Slide
+from slide.views import create_thumbnail
+
+
+class Command(BaseCommand):
+    """
+
+    Usage
+    -----
+    In the console, use the command:
+    ```
+    python manage.py recreate_thumbnails
+    ```
+    """
+
+    help = 'Recreate thumbnails'
+
+    def handle(self, *args, **options):
+        slides = Slide.objects.all()
+        for slide in slides:
+            create_thumbnail(slide.id)
+            print('Thumbnail for', slide.id, 'recreated')

--- a/slide/views.py
+++ b/slide/views.py
@@ -300,7 +300,7 @@ def create_thumbnail(slide_id):
     access = slide.image.getAccess(fast.ACCESS_READ)
     image = access.getLevelAsImage(slide.image.getNrOfLevels()-1)
     scale = float(image.getHeight())/image.getWidth()
-    resize = fast.ImageResizer.create(128, round(128*scale)).connect(image)
+    resize = fast.ImageResizer.create(512, round(512*scale)).connect(image)
     fast.ImageFileExporter\
         .create(f'thumbnails/{slide_id}.jpg')\
         .connect(resize)\


### PR DESCRIPTION
- Insert slides into DB script now uses create_thumbnail instead of copying the thumbnail from the olympus files
- Added a new command called recreate_thumbnails which will update all thumbnails (python manage.py recreate_thumbnails)
- Updated size of thumbnails to width 512 pixels