### PR TITLE
Improved task/do.html for one-to-one and annotation tasks

### DIFF
--- a/annotation_task/templates/annotation_task/do.html
+++ b/annotation_task/templates/annotation_task/do.html
@@ -67,7 +67,7 @@ $(document).ready(function(){
         }
     }
 
-   function createClickReactions(annotations) {
+    function createClickReactions(annotations) {
         var fixedList = document.getElementById('fixed-list');
         var listItems = fixedList.getElementsByTagName('li');
         for (let i = 0; i < listItems.length; i++) {

--- a/annotation_task/templates/annotation_task/do.html
+++ b/annotation_task/templates/annotation_task/do.html
@@ -165,6 +165,13 @@
         }
     }
 
+    function onAddOrEndSortable(event) {
+        resizeListElements();
+        if (taskReadyForSubmit()) {
+            document.getElementById('submit-button').disabled = false;
+        }
+    }
+
     $(document).ready(function(){
         var mode = "{{ mode }}";
         var idOrder = JSON.parse("{{id_order}}");
@@ -177,12 +184,6 @@
         let sortableList = document.getElementById('sortable-list');
         let sortableListInitial = document.getElementById('sortable-list-initial');
 
-        function onAddOrEndSortable(event) {
-            resizeListElements();
-            if (taskReadyForSubmit()) {
-                document.getElementById('submit-button').disabled = false;
-            }
-        }
         let jquerySortable = new Sortable(sortableList, {
             group: 'answers',
             swap: true, // Enable swapping (rather than sorting/shifting elements)

--- a/annotation_task/templates/annotation_task/do.html
+++ b/annotation_task/templates/annotation_task/do.html
@@ -19,7 +19,7 @@
     <form id="my-form" method="POST">
         {% csrf_token %}
         <div class="row">
-            <div class="col">
+            <div class="col col-2">
                 <ul class="list-group " id="fixed-list">
                     {% for annotation in annotations %}
                         <li class="list-group-item ui-state-default " id="fixed-element-{{ forloop.counter }}">{{ annotation.body.0.value }}</li>

--- a/annotation_task/templates/annotation_task/do.html
+++ b/annotation_task/templates/annotation_task/do.html
@@ -11,83 +11,84 @@
 
 
 {% block content_left %}
+<style>
+    .color-hovered-element { background-color: var(--color-blue-light); }
+    .color-drag-handle { color: var(--color-blue-dark); }
+    .list-group-item { min-height: 45px; }
+</style>
     <form id="my-form" method="POST">
+        {% csrf_token %}
         <div class="row">
             <div class="col">
                 <ul class="list-group " id="fixed-list">
                     {% for annotation in annotations %}
-                        <li  class="list-group-item ui-state-default ">{{ annotation.body.0.value }}</li>
+                        <li class="list-group-item ui-state-default " id="fixed-element-{{ forloop.counter }}">{{ annotation.body.0.value }}</li>
                     {% endfor %}
                 </ul>
             </div>
             <div class="col">
-                {% csrf_token %}
                 <ul class="list-group sortable" id="sortable-list">
                     {% for annotation in annotations_correct %}
-                        <li class="list-group-item" id="{{ forloop.counter }}">{{ annotation.body.0.value }}</li>
+                        {% if mode == 'get' %}
+                            <li class="list-group-item" id="sortable-placeholder-{{ forloop.counter }}"></li>
+                        {% else %}
+                            <li class="list-group-item" id="{{ forloop.counter }}">
+                                <span class="iconify drag-handle color-drag-handle" data-icon="fluent:re-order-dots-vertical-24-regular" data-width="24" data-height="24"></span>
+                                {{ annotation.body.0.value }}
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
+            <div class="col">
+                <ul class="list-group sortable" id="sortable-list-initial">
+                    {% for annotation in annotations_correct %}
+                        {% if mode == 'get' %}
+                            <li class="list-group-item" id="{{ forloop.counter }}">
+                                <span class="iconify drag-handle color-drag-handle" data-icon="fluent:re-order-dots-vertical-24-regular" data-width="24" data-height="24"></span>
+                                {{ annotation.body.0.value }}
+                            </li>
+                        {% else %}
+                            <li class="list-group-item" id="sortable-placeholder-{{ forloop.counter }}"></li>
+                        {% endif %}
                     {% endfor %}
                 </ul>
                 <br>
             </div>
         </div>
 
-        <input class="LPButton" type="submit" value="Submit">
+        <input class="LPButton" type="submit" value="Submit" id="submit-button" disabled="disabled">
         <div class="LPButton" style="margin-top: 0; ">
             <a href="{% url next_task.do_url task_id=next_task_id course_id=course_id slide_id=slide_id  %}">Next Task</a>
         </div>
     </form>
 {% endblock content_left %}
 
-<script>
-
-
-</script>
-
 
 {% block task_javascript %}
 
-$(document).ready(function(){
-    var mode = "{{ mode }}";
-    var idOrder = JSON.parse("{{id_order}}");
-    var answerOrder = JSON.parse("{{answer_order}}");
-    var annotations = {{annotations_correct|safe}};
-
-    createClickReactions(annotations);
-    if (mode === 'get') {
-        shuffleList();
-    } else if (mode === 'post') {
-        rearrangeList(idOrder);
-        colorAnswers(idOrder, answerOrder);
-    }
-
     function shuffleList() {
-        var ul = document.querySelector('#sortable-list');
-        for (var i = ul.children.length; i >= 0; i--) {
-            ul.appendChild(ul.children[Math.random() * i | 0]);
+        var sortableListInitial = document.querySelector('#sortable-list-initial');
+        for (var i = sortableListInitial.children.length; i >= 0; i--) {
+            sortableListInitial.appendChild(sortableListInitial.children[Math.random() * i | 0]);
         }
     }
 
     function createClickReactions(annotations) {
+        console.log('Create click reactions');
         var fixedList = document.getElementById('fixed-list');
         var listItems = fixedList.getElementsByTagName('li');
+
         for (let i = 0; i < listItems.length; i++) {
-
-        listItems[i].addEventListener('click', function(event) {
-
-            anno.setVisible(true);
-            visible_annotorious = true;
-            var annotationId = annotations[i]['id'];
-            anno.selectAnnotation(annotationId);
-            anno.fitBoundsWithConstraints(annotationId, {'padding': 200});
-
-        });
+            listItems[i].addEventListener('click', function(event) {
+                anno.setVisible(true);
+                visible_annotorious = true;
+                var annotationId = annotations[i]['id'];
+                anno.selectAnnotation(annotationId);
+                anno.fitBoundsWithConstraints(annotationId, {'padding': 200});
+            });
+        }
     }
-
-        console.log('Create click reactions');
-        anno.setVisible(true);
-
-
-    };
 
     function rearrangeList(order) {
         var list = document.getElementById("sortable-list");
@@ -110,6 +111,42 @@ $(document).ready(function(){
         }
     }
 
+    function resizeListElements() {
+        let fixedListChildren = document.getElementById("fixed-list").children;
+        let sortableListChildren = document.getElementById("sortable-list").children;
+        console.log(fixedListChildren);
+        console.log(sortableListChildren);
+
+        for (let i = 0; i < fixedListChildren.length; i++) {
+            let heightSortableElement = sortableListChildren[i].clientHeight;
+            document.getElementById(fixedListChildren[i].id).style.height = heightSortableElement + "px";
+        }
+    }
+
+    function resizeListElementsInitial() {
+        /* Resize placeholders in the list where answer is given */
+        let fixedListChildren = document.getElementById("fixed-list").children;
+        let sortableListChildren = document.getElementById("sortable-list").children;
+        for (let i = 0; i < fixedListChildren.length; i++) {
+            let heightFixedElement = fixedListChildren[i].clientHeight;
+            document.getElementById(sortableListChildren[i].id).style.height = heightFixedElement + "px";
+        }
+    }
+
+    function taskReadyForSubmit() {
+        /*
+        If any placeholder elements are left in the answer list, task is not ready for submit
+        */
+        let listElements = document.getElementById("sortable-list").children;
+        for (let i = 0; i < listElements.length; i++) {
+            console.log(listElements[i].id);
+            if ( listElements[i].id.includes('placeholder')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     function colorAnswers(idOrder, answerOrder) {
         var list = document.getElementById("sortable-list");
         var items = list.getElementsByTagName("li");
@@ -128,25 +165,69 @@ $(document).ready(function(){
         }
     }
 
+    $(document).ready(function(){
+        var mode = "{{ mode }}";
+        var idOrder = JSON.parse("{{id_order}}");
+        var answerOrder = JSON.parse("{{answer_order}}");
+        var annotations = {{annotations_correct|safe}};
+        anno.setVisible(true);
 
+        createClickReactions(annotations);
 
-    //var sortableList = document.querySelector('.sortable');
-    var sortableList = document.getElementById('sortable-list');
-    var sortable_list = new Sortable(sortableList);
+        let sortableList = document.getElementById('sortable-list');
+        let sortableListInitial = document.getElementById('sortable-list-initial');
 
-    // Capture the order of the list items on form submission
-    var myForm = document.querySelector('#my-form');
-    myForm.addEventListener('submit', function (event) {
-        var itemIds = [];
-        var listItems = document.querySelectorAll('.sortable li');
-        for (var i = 0; i < listItems.length; i++) {
-            itemIds.push(listItems[i].getAttribute('id'));
+        function onAddOrEndSortable(event) {
+            resizeListElements();
+            if (taskReadyForSubmit()) {
+                document.getElementById('submit-button').disabled = false;
+            }
         }
-        var input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = 'item_ids';
-        input.value = itemIds;
-        myForm.appendChild(input);
+        let jquerySortable = new Sortable(sortableList, {
+            group: 'answers',
+            swap: true, // Enable swapping (rather than sorting/shifting elements)
+            swapClass: 'color-hovered-element', // The class applied to the hovered swap item
+            //handle: ".drag-handle",
+            onEnd: onAddOrEndSortable,
+            onAdd: onAddOrEndSortable,
+        });
+        let jquerySortableInitial = new Sortable(sortableListInitial, {
+            group: 'answers',
+            swap: true,
+            swapClass: 'color-hovered-element',
+            onEnd: function(event) {
+                if (taskReadyForSubmit()) {
+                    this.option("disabled", true);
+                }
+            },
+        });
+
+        if (mode === 'get') {
+            shuffleList();
+            resizeListElementsInitial();
+        } else if (mode === 'post') {
+            rearrangeList(idOrder);
+            colorAnswers(idOrder, answerOrder);
+            resizeListElements();
+            jquerySortableInitial.option("disabled", true);
+            if (taskReadyForSubmit()) {
+                document.getElementById('submit-button').disabled = false;
+            };
+        }
+
+        // Capture the order of the list items on form submission
+        var myForm = document.querySelector('#my-form');
+        myForm.addEventListener('submit', function (event) {
+            var itemIds = [];
+            var listItems = document.querySelectorAll('#sortable-list li');
+            for (var i = 0; i < listItems.length; i++) {
+                itemIds.push(listItems[i].getAttribute('id'));
+            }
+            var input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = 'item_ids';
+            input.value = itemIds;
+            myForm.appendChild(input);
+        });
     });
-});
 {% endblock task_javascript %}

--- a/one_to_one/templates/one_to_one/do.html
+++ b/one_to_one/templates/one_to_one/do.html
@@ -12,13 +12,14 @@
 {% block content_left %}
 <style>
     .color-hovered-element { background-color: var(--color-blue-light); }
+    .color-drag-handle { color: var(--color-blue-dark); }
 </style>
     <form id="my-form" method="POST">
         <div class="row">
             <div class="col">
                 <ul class="list-group " id="fixed-list">
                     {% for pair in one_to_one.sortingpair_set.all %}
-                        <li class="list-group-item ui-state-default ui-state-disabled disabled">{{ pair.fixed }}</li>
+                        <li class="list-group-item ui-state-default ui-state-disabled disabled" id="fixed-element-{{ forloop.counter }}">{{ pair.fixed }}</li>
                     {% endfor %}
                 </ul>
             </div>
@@ -26,7 +27,13 @@
                 {% csrf_token %}
                 <ul class="list-group sortable" id="sortable-list">
                     {% for pair in one_to_one.sortingpair_set.all %}
-                        <li class="list-group-item" id="{{ forloop.counter }}">{{ pair.draggable }}</li>
+                        <li class="list-group-item" id="{{ forloop.counter }}">
+                            <!-- TODO: Decide which icon to use. Color? -->
+{#                            <span class="iconify drag-handle" data-icon="fluent:re-order-dots-vertical-24-regular" data-width="24" data-height="24"></span>#}
+{#                            <span class="iconify drag-handle" data-icon="fluent:arrow-bidirectional-up-down-24-regular" data-width="24" data-height="24"></span>#}
+                            <span class="iconify drag-handle color-drag-handle" data-icon="fluent:arrow-bidirectional-up-down-24-regular" data-width="24" data-height="24"></span>
+                            {{ pair.draggable }}
+                        </li>
                     {% endfor %}
                 </ul>
                 <br>
@@ -58,6 +65,7 @@ $(document).ready(function(){
         rearrangeList(idOrder);
         colorAnswers(idOrder, answerOrder);
     }
+    resizeListElements();
 
     function shuffleList() {
         var ul = document.querySelector('#sortable-list');
@@ -87,6 +95,16 @@ $(document).ready(function(){
         }
     }
 
+    function resizeListElements() {
+        let fixedListChildren = document.getElementById("fixed-list").children;
+        let sortableListChildren = document.getElementById("sortable-list").children;
+
+        for (let i = 0; i < fixedListChildren.length; i++) {
+            let heightSortableElement = sortableListChildren[i].clientHeight;
+            document.getElementById(fixedListChildren[i].id).style.height = heightSortableElement + "px";
+        }
+    }
+
     function colorAnswers(idOrder, answerOrder) {
         var list = document.getElementById("sortable-list");
         var items = list.getElementsByTagName("li");
@@ -110,6 +128,10 @@ $(document).ready(function(){
     let jquerySortable = new Sortable(sortableList, {
         swap: true, // Enable swapping (rather than sorting/shifting elements)
         swapClass: 'color-hovered-element', // The class applied to the hovered swap item
+        //handle: ".drag-handle",
+        onEnd: function(event) {
+            resizeListElements();
+        },
     });
 
     // Capture the order of the list items on form submission

--- a/one_to_one/templates/one_to_one/do.html
+++ b/one_to_one/templates/one_to_one/do.html
@@ -10,6 +10,9 @@
 {% endblock task_question %}
 
 {% block content_left %}
+<style>
+    .color-hovered-element { background-color: var(--color-blue-light); }
+</style>
     <form id="my-form" method="POST">
         <div class="row">
             <div class="col">
@@ -103,8 +106,11 @@ $(document).ready(function(){
     }
 
     //var sortableList = document.querySelector('.sortable');
-    var sortableList = document.getElementById('sortable-list');
-    var sortable_list = new Sortable(sortableList);
+    let sortableList = document.getElementById('sortable-list');
+    let jquerySortable = new Sortable(sortableList, {
+        swap: true, // Enable swapping (rather than sorting/shifting elements)
+        swapClass: 'color-hovered-element', // The class applied to the hovered swap item
+    });
 
     // Capture the order of the list items on form submission
     var myForm = document.querySelector('#my-form');

--- a/one_to_one/templates/one_to_one/do.html
+++ b/one_to_one/templates/one_to_one/do.html
@@ -67,11 +67,6 @@
 
 {% block task_javascript %}
 
-$(document).ready(function(){
-    var mode = "{{ mode }}"; //document.getElementById('mode').dataset.mode;
-    var idOrder = JSON.parse("{{id_order}}");
-    var answerOrder = JSON.parse("{{answer_order}}");
-
     function shuffleList() {
         var sortableListInitial = document.querySelector('#sortable-list-initial');
         for (var i = sortableListInitial.children.length; i >= 0; i--) {
@@ -152,63 +147,70 @@ $(document).ready(function(){
         }
     }
 
-    let sortableList = document.getElementById('sortable-list');
-    let sortableListInitial = document.getElementById('sortable-list-initial');
-
     function onAddOrEndSortable(event) {
         resizeListElements();
         if (taskReadyForSubmit()) {
             document.getElementById('submit-button').disabled = false;
         }
     }
-    let jquerySortable = new Sortable(sortableList, {
-        group: 'answers',
-        swap: true, // Enable swapping (rather than sorting/shifting elements)
-        swapClass: 'color-hovered-element', // The class applied to the hovered swap item
-        //handle: ".drag-handle",
-        onEnd: onAddOrEndSortable,
-        onAdd: onAddOrEndSortable,
-    });
-    let jquerySortableInitial = new Sortable(sortableListInitial, {
-        group: 'answers',
-        swap: true,
-        swapClass: 'color-hovered-element',
-        onEnd: function(event) {
+
+    $(document).ready(function(){
+        var mode = "{{ mode }}"; //document.getElementById('mode').dataset.mode;
+        var idOrder = JSON.parse("{{id_order}}");
+        var answerOrder = JSON.parse("{{answer_order}}");
+
+        let sortableList = document.getElementById('sortable-list');
+        let sortableListInitial = document.getElementById('sortable-list-initial');
+
+        let jquerySortable = new Sortable(sortableList, {
+            group: 'answers',
+            swap: true, // Enable swapping (rather than sorting/shifting elements)
+            swapClass: 'color-hovered-element', // The class applied to the hovered swap item
+            //handle: ".drag-handle",
+            onEnd: onAddOrEndSortable,
+            onAdd: onAddOrEndSortable,
+        });
+        let jquerySortableInitial = new Sortable(sortableListInitial, {
+            group: 'answers',
+            swap: true,
+            swapClass: 'color-hovered-element',
+            onEnd: function(event) {
+                if (taskReadyForSubmit()) {
+                    this.option("disabled", true);
+                }
+            },
+        });
+
+        if (mode === 'get') {
+            console.log('Shuffle List.')
+            shuffleList();
+            resizeListElementsInitial();
+        } else if (mode === 'post') {
+            console.log(idOrder);
+            console.log("Don't shuffle List.");
+            rearrangeList(idOrder);
+            colorAnswers(idOrder, answerOrder);
+            resizeListElements();
+            jquerySortableInitial.option("disabled", true);
             if (taskReadyForSubmit()) {
-                this.option("disabled", true);
-            }
-        },
-    });
-
-    if (mode === 'get') {
-        console.log('Shuffle List.')
-        shuffleList();
-        resizeListElementsInitial();
-    } else if (mode === 'post') {
-        console.log(idOrder);
-        console.log("Don't shuffle List.");
-        rearrangeList(idOrder);
-        colorAnswers(idOrder, answerOrder);
-        resizeListElements();
-        jquerySortableInitial.option("disabled", true);
-        if (taskReadyForSubmit()) {
-            document.getElementById('submit-button').disabled = false;
-        };
-    }
-
-    // Capture the order of the list items on form submission
-    var myForm = document.querySelector('#my-form');
-    myForm.addEventListener('submit', function (event) {
-        var itemIds = [];
-        var listItems = document.querySelectorAll('#sortable-list li');
-        for (var i = 0; i < listItems.length; i++) {
-            itemIds.push(listItems[i].getAttribute('id'));
+                document.getElementById('submit-button').disabled = false;
+            };
         }
-        var input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = 'item_ids';
-        input.value = itemIds;
-        myForm.appendChild(input);
+
+        // Capture the order of the list items on form submission
+        var myForm = document.querySelector('#my-form');
+        myForm.addEventListener('submit', function (event) {
+            var itemIds = [];
+            var listItems = document.querySelectorAll('#sortable-list li');
+            for (var i = 0; i < listItems.length; i++) {
+                itemIds.push(listItems[i].getAttribute('id'));
+            }
+            var input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = 'item_ids';
+            input.value = itemIds;
+            myForm.appendChild(input);
+        });
     });
-});
+
 {% endblock task_javascript %}

--- a/one_to_one/templates/one_to_one/do.html
+++ b/one_to_one/templates/one_to_one/do.html
@@ -16,6 +16,7 @@
     .list-group-item { min-height: 45px; }
 </style>
     <form id="my-form" method="POST">
+        {% csrf_token %}
         <div class="row">
             <div class="col">
                 <ul class="list-group " id="fixed-list">
@@ -25,7 +26,6 @@
                 </ul>
             </div>
             <div class="col">
-                {% csrf_token %}
                 <ul class="list-group sortable" id="sortable-list">
                     {% for pair in one_to_one.sortingpair_set.all %}
                         {% if mode == 'get' %}
@@ -42,7 +42,6 @@
                 <div id="mode" data-mode="{{ mode }}"></div>
             </div>
             <div class="col">
-                {% csrf_token %}
                 <ul class="list-group sortable" id="sortable-list-initial">
                     {% for pair in one_to_one.sortingpair_set.all %}
                         {% if mode == 'get' %}
@@ -160,7 +159,7 @@ $(document).ready(function(){
         resizeListElements();
         if (taskReadyForSubmit()) {
             document.getElementById('submit-button').disabled = false;
-        };
+        }
     }
     let jquerySortable = new Sortable(sortableList, {
         group: 'answers',

--- a/one_to_one/templates/one_to_one/do.html
+++ b/one_to_one/templates/one_to_one/do.html
@@ -58,7 +58,7 @@
             </div>
         </div>
 
-        <input class="LPButton" type="submit" value="Submit" id="submit-button" disabled="true">
+        <input class="LPButton" type="submit" value="Submit" id="submit-button" disabled="disabled">
         <div class="LPButton" style="margin-top: 0; ">
             <a href="{% url next_task.do_url task_id=next_task_id course_id=course_id slide_id=slide_id %}">Next Task</a>
         </div>

--- a/one_to_one/templates/one_to_one/do.html
+++ b/one_to_one/templates/one_to_one/do.html
@@ -13,6 +13,7 @@
 <style>
     .color-hovered-element { background-color: var(--color-blue-light); }
     .color-drag-handle { color: var(--color-blue-dark); }
+    .list-group-item { min-height: 45px; }
 </style>
     <form id="my-form" method="POST">
         <div class="row">
@@ -27,21 +28,37 @@
                 {% csrf_token %}
                 <ul class="list-group sortable" id="sortable-list">
                     {% for pair in one_to_one.sortingpair_set.all %}
-                        <li class="list-group-item" id="{{ forloop.counter }}">
-                            <!-- TODO: Decide which icon to use. Color? -->
-{#                            <span class="iconify drag-handle" data-icon="fluent:re-order-dots-vertical-24-regular" data-width="24" data-height="24"></span>#}
-{#                            <span class="iconify drag-handle" data-icon="fluent:arrow-bidirectional-up-down-24-regular" data-width="24" data-height="24"></span>#}
-                            <span class="iconify drag-handle color-drag-handle" data-icon="fluent:arrow-bidirectional-up-down-24-regular" data-width="24" data-height="24"></span>
-                            {{ pair.draggable }}
-                        </li>
+                        {% if mode == 'get' %}
+                            <li class="list-group-item" id="sortable-placeholder-{{ forloop.counter }}"></li>
+                        {% else %}
+                            <li class="list-group-item" id="{{ forloop.counter }}">
+                                <span class="iconify drag-handle color-drag-handle" data-icon="fluent:re-order-dots-vertical-24-regular" data-width="24" data-height="24"></span>
+                                {{ pair.draggable }}
+                            </li>
+                        {% endif %}
                     {% endfor %}
                 </ul>
                 <br>
                 <div id="mode" data-mode="{{ mode }}"></div>
             </div>
+            <div class="col">
+                {% csrf_token %}
+                <ul class="list-group sortable" id="sortable-list-initial">
+                    {% for pair in one_to_one.sortingpair_set.all %}
+                        {% if mode == 'get' %}
+                            <li class="list-group-item" id="{{ forloop.counter }}">
+                                <span class="iconify drag-handle color-drag-handle" data-icon="fluent:re-order-dots-vertical-24-regular" data-width="24" data-height="24"></span>
+                                {{ pair.draggable }}
+                            </li>
+                        {% else %}
+                            <li class="list-group-item" id="sortable-placeholder-{{ forloop.counter }}"></li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
         </div>
 
-        <input class="LPButton" type="submit" value="Submit">
+        <input class="LPButton" type="submit" value="Submit" id="submit-button" disabled="true">
         <div class="LPButton" style="margin-top: 0; ">
             <a href="{% url next_task.do_url task_id=next_task_id course_id=course_id slide_id=slide_id %}">Next Task</a>
         </div>
@@ -56,21 +73,10 @@ $(document).ready(function(){
     var idOrder = JSON.parse("{{id_order}}");
     var answerOrder = JSON.parse("{{answer_order}}");
 
-    if (mode === 'get') {
-        console.log('Shuffle List.')
-        shuffleList();
-    } else if (mode === 'post') {
-        console.log(idOrder);
-        console.log("Don't shuffle List.");
-        rearrangeList(idOrder);
-        colorAnswers(idOrder, answerOrder);
-    }
-    resizeListElements();
-
     function shuffleList() {
-        var ul = document.querySelector('#sortable-list');
-        for (var i = ul.children.length; i >= 0; i--) {
-            ul.appendChild(ul.children[Math.random() * i | 0]);
+        var sortableListInitial = document.querySelector('#sortable-list-initial');
+        for (var i = sortableListInitial.children.length; i >= 0; i--) {
+            sortableListInitial.appendChild(sortableListInitial.children[Math.random() * i | 0]);
         }
     }
 
@@ -105,6 +111,30 @@ $(document).ready(function(){
         }
     }
 
+    function resizeListElementsInitial() {
+        /* Resize placeholders in the list where answer is given */
+        let fixedListChildren = document.getElementById("fixed-list").children;
+        let sortableListChildren = document.getElementById("sortable-list").children;
+        for (let i = 0; i < fixedListChildren.length; i++) {
+            let heightFixedElement = fixedListChildren[i].clientHeight;
+            document.getElementById(sortableListChildren[i].id).style.height = heightFixedElement + "px";
+        }
+    }
+
+    function taskReadyForSubmit() {
+        /*
+        If any placeholder elements are left in the answer list, task is not ready for submit
+        */
+        let listElements = document.getElementById("sortable-list").children;
+        for (let i = 0; i < listElements.length; i++) {
+            console.log(listElements[i].id);
+            if ( listElements[i].id.includes('placeholder')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     function colorAnswers(idOrder, answerOrder) {
         var list = document.getElementById("sortable-list");
         var items = list.getElementsByTagName("li");
@@ -125,20 +155,54 @@ $(document).ready(function(){
 
     //var sortableList = document.querySelector('.sortable');
     let sortableList = document.getElementById('sortable-list');
+    let sortableListInitial = document.getElementById('sortable-list-initial');
+
+    function onAddOrEndSortable(event) {
+        resizeListElements();
+        if (taskReadyForSubmit()) {
+            document.getElementById('submit-button').disabled = false;
+        };
+    }
     let jquerySortable = new Sortable(sortableList, {
+        group: 'answers',
         swap: true, // Enable swapping (rather than sorting/shifting elements)
         swapClass: 'color-hovered-element', // The class applied to the hovered swap item
         //handle: ".drag-handle",
+        onEnd: onAddOrEndSortable,
+        onAdd: onAddOrEndSortable,
+    });
+    let jquerySortableInitial = new Sortable(sortableListInitial, {
+        group: 'answers',
+        swap: true,
+        swapClass: 'color-hovered-element',
         onEnd: function(event) {
-            resizeListElements();
+            if (taskReadyForSubmit()) {
+                this.option("disabled", true);
+            }
         },
     });
+
+    if (mode === 'get') {
+        console.log('Shuffle List.')
+        shuffleList();
+        resizeListElementsInitial();
+    } else if (mode === 'post') {
+        console.log(idOrder);
+        console.log("Don't shuffle List.");
+        rearrangeList(idOrder);
+        colorAnswers(idOrder, answerOrder);
+        resizeListElements();
+        jquerySortableInitial.option("disabled", true);
+        if (taskReadyForSubmit()) {
+            document.getElementById('submit-button').disabled = false;
+        };
+    }
 
     // Capture the order of the list items on form submission
     var myForm = document.querySelector('#my-form');
     myForm.addEventListener('submit', function (event) {
         var itemIds = [];
-        var listItems = document.querySelectorAll('.sortable li');
+        var listItems = document.querySelectorAll('#sortable-list li');
         for (var i = 0; i < listItems.length; i++) {
             itemIds.push(listItems[i].getAttribute('id'));
         }

--- a/one_to_one/templates/one_to_one/do.html
+++ b/one_to_one/templates/one_to_one/do.html
@@ -153,7 +153,6 @@ $(document).ready(function(){
         }
     }
 
-    //var sortableList = document.querySelector('.sortable');
     let sortableList = document.getElementById('sortable-list');
     let sortableListInitial = document.getElementById('sortable-list-initial');
 


### PR DESCRIPTION
This PR implements the following changes to one-to-one and annotation task:
- Three-column layout (fixed column, answer column, and column where possible answers are originally placed)
- Elements are swapped upon drag/drop instead of the following elements in the list being shifted
- Improved formatting/styling. E.g. elements automatically resize so the fixed column and answer column are aligned. This makes it easier to see which answer belongs to which row/element in the fixed column.